### PR TITLE
Add ability to exclusively subscribe to chat events

### DIFF
--- a/src/Room.ts
+++ b/src/Room.ts
@@ -114,6 +114,20 @@ class Room extends EventEmitter {
     }
 
     /**
+     * @summary exclusively subscribes to a list of events
+     * @param eventType event type 
+     */
+    public only(...eventType: ChatEventType[]): void {
+        const allow = new Set(eventType);
+
+        const ignore = Object
+            .values(ChatEventType)
+            .filter((v) => !allow.has(v as ChatEventType));
+
+        return this.ignore(...ignore as ChatEventType[]);
+    }
+
+    /**
      * Join a chat room
      *
      * @returns {Promise<boolean>} A promise when the user succesfully joins this room

--- a/tests/unit/room.test.ts
+++ b/tests/unit/room.test.ts
@@ -240,6 +240,19 @@ describe("Room", () => {
             const msg = (await promise) as WebsocketEvent;
             expect(msg.eventType).toBe(notIgnored);
         });
+
+        test("should ignore all other events if added via Room#only()", () => {
+            const roomId = 5;
+            const client = new Client("stackoverflow.com");
+            const room = new Room(client, roomId);
+
+            room.only(ChatEventType.FILE_ADDED);
+
+            Object.values(ChatEventType).forEach((v) => {
+                const ignored = room.isIgnored(v as ChatEventType);
+                expect(v === ChatEventType.FILE_ADDED || ignored).toBe(true);
+            });
+        });
     });
 
     it("Should create a room with id", () => {


### PR DESCRIPTION
This PR lets clients explicitly subscribe to a list of events in a room while automatically adding others to ignore list.
Currently, to emulate this behaviour, clients have to specify every chat event they want to ignore, which is verbose.
It can lead to issues we can address with such a feature early, like forgetting to ignore or properly handle an event type.

Type assertions are required as iterating string enums loses type information about enum values, resulting in a `string | <enum>` union type that has to be asserted to back to the enum type (as it is guaranteed at runtime).