### PR TITLE
NPM publishing workflow and README update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     open-pull-requests-limit: 5
     rebase-strategy: "auto"
-    target-branch: "master"
+    target-branch: "main"
     labels:
       - "chores"
     schedule:

--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -1,9 +1,9 @@
-name: "Push to master"
+name: "Push to main"
 on: push
 jobs:
   docs:
-    # running only on master branch pushes
-    if: ${{ github.ref_name == 'master' && github.ref_type == 'branch' }}
+    # running only on main branch pushes
+    if: ${{ github.ref_name == 'main' && github.ref_type == 'branch' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -21,4 +21,4 @@ jobs:
           git add docs &&
           git commit -am "regenerated documentation at $( date -I'minutes' )"
           git push
-          
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - master
     tags:
       - v*.*.*
       - v*.*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: "Publish"
+
+# the workflow is only triggered on version tag pushes to the master branch
+on:
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - v*.*.*
+      - v*.*
+
+jobs:
+    publish-npm:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: 14
+                  registry-url: "https://registry.npmjs.org"
+            - run: npm ci
+            - run: npm test
+            - if: ${{ success() }}
+              run: |
+                  npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
+                  npm publish --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "ts-node src/index.ts",
     "build": "rimraf dist && tsc --declaration",
     "prepare": "npm run build",
-    "pretest": "npm run build",
+    "preversion": "npm test",
     "test": "jest --config='jest.config.json' --collectCoverage --collectCoverageFrom='src/**/*.ts' --coverageReporters='lcov' --silent=false",
     "pretest-coveralls": "npm run build",
     "test-coveralls": "jest --config='jest.config.json' --collectCoverage --collectCoverageFrom='src/**/*.ts' --coverageProvider='v8' --coverageReporters='text-lcov' | coveralls && tslint 'src/**/*.ts'"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "docs": "rimraf docs && typedoc",
     "start": "ts-node src/index.ts",
     "build": "rimraf dist && tsc --declaration",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "pretest": "npm run build",
     "test": "jest --config='jest.config.json' --collectCoverage --collectCoverageFrom='src/**/*.ts' --coverageReporters='lcov' --silent=false",
     "pretest-coveralls": "npm run build",


### PR DESCRIPTION
This small PR adds makes two utility-centered changes:

- adds a GitHub workflow for publishing a new version to NPM (strict trigger: only when a new version tag is pushed to master)
- updates the README: a couple of capitalization fixes + expanding on the usage example to include most of the new features
- replaces the `prepublish` NPM lifecycle hook with a semantically similar `prepare` hook (`prepublish` [is deprecated](https://docs.npmjs.com/cli/v8/using-npm/scripts#prepare-and-prepublish))
- replaces the `pretest` NPM lifecycle hook with a `preversion` hook (there is no need to `npm run build` during testing as it is done on the source, but there is a need to `npm test` before bumping a version to avoid cleaning up if the version is defective)

@samliew may I ask you to add an `NPM_TOKEN` secret to the repo (if not added already) for the workflow to be able to run successfully? Then republishing the package will be as simple as `npm version <major|minor|patch>` and `git push origin <tagname>`.