### PR TITLE
Joining and leaving rooms should add/remove rooms from the client's internal storage

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,5 +1,5 @@
 import { validate } from "email-validator";
-import Browser, { type ITranscriptData, type IProfileData } from "./Browser";
+import Browser, { type IProfileData, type ITranscriptData } from "./Browser";
 import ChatExchangeError from "./Exceptions/ChatExchangeError";
 import InvalidArgumentError from "./Exceptions/InvalidArgumentError";
 import Message from "./Message";
@@ -113,17 +113,24 @@ export class Client {
         return browser.getProfile(user);
     }
 
-    public getRoom(id: number): Room {
-        let room = this.#rooms.get(id);
-        if (room) {
-            return room;
+    /**
+     * @summary gets a {@link Room} instance from the client
+     * @param room {@link Room} or {@link Room.id} to get
+     */
+    public getRoom(room: number | Room): Room {
+        const rooms = this.#rooms;
+
+        const isId = typeof room === "number";
+        const roomId = isId ? room : room.id;
+
+        const existingRoom = rooms.get(roomId);
+        if (existingRoom) {
+            return existingRoom;
         }
 
-        room = new Room(this, id);
-
-        this.#rooms.set(id, room);
-
-        return room;
+        const newRoom = isId ? new Room(this, roomId) : room;
+        rooms.set(roomId, newRoom);
+        return newRoom;
     }
 
     /**

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -212,7 +212,7 @@ export class Client {
      * @memberof Client#
      */
     public async joinRoom(room: number | Room): Promise<boolean> {
-        return this.#browser.joinRoom(room);
+        return this.#browser.joinRoom(this.getRoom(room));
     }
 
     /**

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -217,12 +217,14 @@ export class Client {
 
     /**
      * @summary Leaves a given room
-     * @param room The room or ID to leave
+     * @param room The {@link Room} or ID to leave
      * @returns {Promise<boolean>}
-     * @memberof Client#
      */
-    public leaveRoom(room: number | Room): Promise<boolean> {
-        return this.#browser.leaveRoom(room);
+    public async leaveRoom(room: number | Room): Promise<boolean> {
+        const roomToLeave = this.getRoom(room);
+        const status = await this.#browser.leaveRoom(roomToLeave);
+        if (status) this.#rooms.delete(roomToLeave.id);
+        return status;
     }
 
     /**

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -3,6 +3,7 @@ import Client, { Host } from "../../src/Client";
 import ChatExchangeError from "../../src/Exceptions/ChatExchangeError";
 import InvalidArgumentError from "../../src/Exceptions/InvalidArgumentError";
 import Message from "../../src/Message";
+import Room from "../../src/Room";
 import User from "../../src/User";
 
 describe("Client", () => {
@@ -20,6 +21,24 @@ describe("Client", () => {
         await expect(
             new Client("stackoverflow.com").getMe()
         ).rejects.toThrowError(ChatExchangeError);
+    });
+
+    describe("Rooms", () => {
+        test("Should add rooms to the internal list of rooms when requested", () => {
+            const client = new Client("stackexchange.com");
+
+            const room1Id = 42;
+            const room2Id = 24;
+
+            client.getRoom(room1Id);
+            client.getRoom(new Room(client, room2Id));
+
+            const rooms = client.getRooms();
+
+            expect(rooms.size).toEqual(2);
+            expect(rooms.get(room1Id)?.id).toEqual(room1Id);
+            expect(rooms.get(room2Id)?.id).toEqual(room2Id);
+        });
     });
 
     describe("Login", () => {

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -185,10 +185,11 @@ describe("Client", () => {
 
         const client = new Client(host);
         const browser = new BrowserMock(client);
+        const room = client.getRoom(roomId);
 
-        const status = await client.joinRoom(roomId);
+        const status = await room.join();
 
-        expect(browser.joinRoom).toHaveBeenCalledWith(roomId);
+        expect(browser.joinRoom).toHaveBeenCalledWith(room);
         expect(status).toBe(true);
     });
 


### PR DESCRIPTION
If the caller joins a room via an explicit `joinRoom` call, the room will not be added to the list of joined rooms without a separate call to the `getRoom` method. This means that `getRooms` or `getRoomsAsArray` methods return an incorrect number of rooms. The PR makes the former method call the latter implicitly to solve that.

Also, the PR adds a reverse operation when calling `leaveRoom` as does not make sense that the client still lists any room the bot left already when calling either `getRooms` or `getRoomsAsArray` methods.