### PR TITLE
'getTranscript' and 'getProfile' should throw specific errors on missing pages

### DIFF
--- a/src/Browser.ts
+++ b/src/Browser.ts
@@ -150,7 +150,7 @@ export class Browser {
     ): Promise<void> {
         this.#cookieJar = CookieJar.deserializeSync(cookie);
 
-        const $ = await this.#get$(`https://${this.#client.host}/`);
+        const [, $] = await this.#get$(`https://${this.#client.host}/`);
 
         const res = $("input[name=fkey]:not([value=''])");
 
@@ -282,7 +282,7 @@ export class Browser {
 
         const roomid = typeof room === "number" ? room : room.id;
 
-        const $ = await this.#get$(`${root}rooms/info/${roomid}`, {
+        const [, $] = await this.#get$(`${root}rooms/info/${roomid}`, {
             id: roomid,
             tag: "general",
             users: "current",
@@ -358,7 +358,7 @@ export class Browser {
     public async getProfile(user: number | User): Promise<IProfileData> {
         const userId = typeof user === "number" ? user : user.id;
 
-        const $ = await this.#get$(`users/${userId}`);
+        const [, $] = await this.#get$(`users/${userId}`);
 
         const name = $("h1").text();
         const isModerator = $(".user-status").first().text().includes("♦");
@@ -433,7 +433,7 @@ export class Browser {
             throw new ChatExchangeError("cannot get a transcript of an invalid message");
         }
 
-        const $ = await this.#get$(`transcript/message/${msgId}`);
+        const [, $] = await this.#get$(`transcript/message/${msgId}`);
 
         const $msg = $(".message.highlight");
         const $room = $(".room-name a");
@@ -561,7 +561,7 @@ export class Browser {
      * @returns {Promise<void>}
      */
     async #updateChatFKeyAndUser(): Promise<void> {
-        const $ = await this.#get$("chats/join/favorite");
+        const [, $] = await this.#get$("chats/join/favorite");
         this.#loadFKey($);
         this.#loadUser($);
     }
@@ -626,13 +626,12 @@ export class Browser {
      * @private
      *
      * @summary cheeiro parsed data request helper
-     * @param {string} uri request URI
-     * @param {object} [qs] query string data
-     * @returns {Promise<import("cheerio").Root>}
+     * @param uri request URI
+     * @param [qs] query string data
      */
-    async #get$(uri: string, qs = {}) {
+    async #get$(uri: string, qs = {}): Promise<[code: number, page: cheerio.Root]> {
         const res = await this.#request<string>("get", uri, {}, qs);
-        return cheerio.load(res.body);
+        return [res.statusCode, cheerio.load(res.body)];
     }
 
     /**
@@ -701,7 +700,7 @@ export class Browser {
 
         const url = `https://${loginHost}/${path.replace(/^\//, "")}`;
 
-        const $ = await this.#get$(url);
+        const [, $] = await this.#get$(url);
 
         const fkeySelector = 'input[name="fkey"]';
         const fkeyElem = $(fkeySelector);

--- a/src/Browser.ts
+++ b/src/Browser.ts
@@ -376,7 +376,11 @@ export class Browser {
     public async getProfile(user: number | User): Promise<IProfileData> {
         const userId = typeof user === "number" ? user : user.id;
 
-        const [, $] = await this.#get$(`users/${userId}`);
+        const [code, $] = await this.#get$(`users/${userId}`, { mutedStatusCodes: [404] });
+
+        if (code === 404) {
+            throw new ScrapingError(`failed to get user #${userId}`, $.html());
+        }
 
         const name = $("h1").text();
         const isModerator = $(".user-status").first().text().includes("♦");
@@ -451,7 +455,11 @@ export class Browser {
             throw new ChatExchangeError("cannot get a transcript of an invalid message");
         }
 
-        const [, $] = await this.#get$(`transcript/message/${msgId}`);
+        const [code, $] = await this.#get$(`transcript/message/${msgId}`, { mutedStatusCodes: [404] });
+
+        if (code === 404) {
+            throw new ScrapingError(`failed to get message #${msgId}`, $.html());
+        }
 
         const $msg = $(".message.highlight");
         const $room = $(".room-name a");

--- a/tests/unit/browser.test.ts
+++ b/tests/unit/browser.test.ts
@@ -173,8 +173,8 @@ describe("Browser", () => {
     describe("profile scraping", () => {
         beforeEach(() => jest.resetModules());
 
-        it("getProfile", async () => {
-            expect.assertions(8);
+        it(Browser.prototype.getProfile.name, async () => {
+            expect.assertions(9);
 
             const mockGot = jest.fn();
             jest.doMock("got", () => {
@@ -182,6 +182,9 @@ describe("Browser", () => {
             });
 
             const { default: Browser } = await import("../../src/Browser");
+            const { ScrapingError } = await import(
+                "../../src/Exceptions/ScrapingError"
+            );
 
             const client = new Client("meta.stackexchange.com");
             const browser = new Browser(client);
@@ -229,6 +232,13 @@ describe("Browser", () => {
             const empty = await browser.getProfile(-1);
             expect(empty.reputation).toEqual(1);
             expect(empty.parentId).toBeUndefined();
+
+            mockGot.mockReturnValueOnce({
+                statusCode: 404,
+                body: "not found",
+            });
+
+            await expect(browser.getProfile(0)).rejects.toBeInstanceOf(ScrapingError);
         });
     });
 


### PR DESCRIPTION
We should throw early in case the supplied user id leads to a 404 page instead of failing late during parsing with a stack trace that is generally unhelpful for dependent programs. This PR addresses that for the `getTranscript` and `getProfile` low-level `Browser` methods + tweaks the signatures of the internal request methods to allow for higher flexibility of request configuration (specifically, allows us to choose which HTTP error codes to mute to handle downstream in a more specific manner).

closes #191 