### PR TITLE
Room creation/updating methods and test suites rework

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.preferences.importModuleSpecifierEnding": "minimal"
+}

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,5 +1,5 @@
 import { validate } from "email-validator";
-import Browser, { DeleteMessageStatus, type IProfileData, type ITranscriptData } from "./Browser";
+import Browser, { DeleteMessageStatus, IRoomSave, type IProfileData, type ITranscriptData } from "./Browser";
 import ChatExchangeError from "./Exceptions/ChatExchangeError";
 import InvalidArgumentError from "./Exceptions/InvalidArgumentError";
 import Message from "./Message";
@@ -124,6 +124,33 @@ export class Client {
     public getProfile(user: number | User): Promise<IProfileData> {
         const browser = this.#browser;
         return browser.getProfile(user);
+    }
+
+    /**
+     * @summary attempts to update a {@link Room}
+     * @param config {@link Room} configuration options
+     */
+    public async createRoom(config: Omit<IRoomSave, "host">): Promise<Room> {
+        const { host } = this;
+        const browser = this.#browser;
+        const roomId = await browser.createRoom({ ...config, host });
+        return new Room(this, roomId);
+    }
+    
+    /**
+     * @summary attempts to update a {@link Room}
+     * @param room {@link Room} or {@link Room.id} to update
+     * @param config {@link Room} configuration options
+     */
+    public async updateRoom(
+        room: number | Room,
+        config: Omit<IRoomSave, "host">,
+    ): Promise<Room> {
+        const { host } = this;
+        const roomId = typeof room === "number" ? room : room.id;
+        const broswer = this.#browser;
+        const newRoomId = await broswer.updateRoom(roomId, { ...config, host });
+        return new Room(this, newRoomId);
     }
 
     /**

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -82,6 +82,13 @@ export class Client {
     }
 
     /**
+     * @summary gets user login status
+     */
+    public get loggedIn(): boolean {
+        return this.#browser.loggedIn;
+    }
+
+    /**
      * Fetches the current logged-in user's profile
      *
      * @returns {Promise<User>} The user object
@@ -89,13 +96,11 @@ export class Client {
      * @memberof Client#
      */
     public async getMe(): Promise<User> {
-        const browser = this.#browser;
-
-        if (!browser.loggedIn) {
+        if (!this.loggedIn) {
             throw new ChatExchangeError("Cannot get user, not logged in.");
         }
 
-        return new User(this, await browser.userId);
+        return new User(this, await this.#browser.userId);
     }
 
     public getMessage(id: number): Message {

--- a/src/Room.ts
+++ b/src/Room.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "events";
-import WebSocket from "ws";
-import { DeleteMessageStatus } from "./Browser.js";
-import Client from "./Client";
+import type WebSocket from "ws";
+import { DeleteMessageStatus, type IRoomSave } from "./Browser.js";
+import type Client from "./Client";
 import InvalidArgumentError from "./Exceptions/InvalidArgumentError";
 import Message from "./Message";
 import User from "./User";
@@ -42,6 +42,20 @@ class Room extends EventEmitter {
         const { host } = this.#client;
         const { id } = this;
         return `https://chat.${host}/transcript/${id}`;
+    }
+
+    /**
+     * @summary attempts to update the room
+     * @param config {@link Room} configuration options
+     */
+    public async update(config: Omit<IRoomSave, "host">): Promise<boolean> {
+        try {
+            await this.#client.updateRoom(this, config);
+            return true;
+        } catch (error) {
+            console.error(error);
+            return false;
+        }
     }
 
     /**
@@ -131,11 +145,11 @@ class Room extends EventEmitter {
     public only(...eventType: ChatEventType[]): void {
         const allow = new Set(eventType);
 
-        const ignore = Object
-            .values(ChatEventType)
-            .filter((v) => !allow.has(v as ChatEventType));
+        const ignore = Object.values(ChatEventType).filter(
+            (v) => !allow.has(v as ChatEventType)
+        );
 
-        return this.ignore(...ignore as ChatEventType[]);
+        return this.ignore(...(ignore as ChatEventType[]));
     }
 
     /**
@@ -175,7 +189,9 @@ class Room extends EventEmitter {
      * @summary deletes a given message
      * @param message {@link Message} or ID to delete
      */
-    public async delete(message: number | Message): Promise<DeleteMessageStatus> {
+    public async delete(
+        message: number | Message
+    ): Promise<DeleteMessageStatus> {
         return this.#client.delete(message);
     }
 

--- a/tests/fixtures/create_room_body.json
+++ b/tests/fixtures/create_room_body.json
@@ -1,0 +1,6 @@
+{
+  "defaultAccess": "read-only",
+  "description": "Test room for CE",
+  "name": "ChatExchange",
+  "tags": ["chat", "chatbot"]
+}

--- a/tests/fixtures/update_room_body.json
+++ b/tests/fixtures/update_room_body.json
@@ -1,0 +1,5 @@
+{
+  "defaultAccess": "read-write",
+  "description": "Testing ChatExchange functionality",
+  "name": "CE test room"
+}

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -1,38 +1,70 @@
-import Browser, { DeleteMessageStatus } from "../../src/Browser";
-import Client, { AllowedHosts, Host, isAllowedHost } from "../../src/Client";
+import Browser, {
+    DeleteMessageStatus,
+    type IRoomSave,
+} from "../../src/Browser";
+import Client, { AllowedHosts, isAllowedHost } from "../../src/Client";
 import ChatExchangeError from "../../src/Exceptions/ChatExchangeError";
 import InvalidArgumentError from "../../src/Exceptions/InvalidArgumentError";
 import Message from "../../src/Message";
 import Room from "../../src/Room";
 import User from "../../src/User";
+import createRoomBody from "../fixtures/create_room_body.json";
+import updateRoomBody from "../fixtures/update_room_body.json";
+import { makeMockClassExport } from "./utils";
 
-describe("Client", () => {
-    test(isAllowedHost.name, () => {
-        expect.assertions(1 + AllowedHosts.length);
+const mockBrowser = makeMockClassExport<Browser>("../../src/Browser");
+const mockClient = makeMockClassExport<Client>("../../src/Client");
+const mockRoom = makeMockClassExport<Room>("../../src/Room");
 
-        const notAllowed = isAllowedHost("example.com");
-        expect(notAllowed).toEqual(false);
+describe(Client.name, () => {
+    beforeEach(() => jest.resetModules());
 
-        AllowedHosts.forEach((host) => {
-            const allowed = isAllowedHost(host);
-            expect(allowed).toEqual(true);
+    describe("Instantiation", () => {
+        test("Should throw error if invalid host", () => {
+            expect.assertions(1);
+
+            //@ts-ignore
+            expect(() => new Client("example.com")).toThrowError(
+                InvalidArgumentError
+            );
+        });
+
+        test("Should throw error if not logged in", async () => {
+            expect.assertions(1);
+
+            await expect(
+                new Client("stackoverflow.com").getMe()
+            ).rejects.toThrowError(ChatExchangeError);
         });
     });
 
-    test("Should throw error if invalid host", () => {
-        expect.assertions(1);
+    describe("Getters", () => {
+        test("Should correctly get root", () => {
+            expect.assertions(1);
 
-        //@ts-ignore
-        expect(() => new Client("example.com")).toThrowError(
-            InvalidArgumentError
-        );
-    });
-    test("Should throw error if not logged in", async () => {
-        expect.assertions(1);
+            const clients = AllowedHosts.map((host) => new Client(host));
+            const roots = clients.map(({ root }) => root);
 
-        await expect(
-            new Client("stackoverflow.com").getMe()
-        ).rejects.toThrowError(ChatExchangeError);
+            expect(roots).toEqual([
+                "https://chat.stackexchange.com/",
+                "https://chat.meta.stackexchange.com/",
+                "https://chat.stackoverflow.com/",
+            ]);
+        });
+
+        test("Should correctly get fkey", async () => {
+            expect.assertions(1);
+
+            const mockFkey = "42";
+
+            mockBrowser({ chatFKey: Promise.resolve(mockFkey) });
+            const { default: Browser } = await import("../../src/Browser");
+
+            const client = new Client("stackexchange.com");
+            client.browser = new Browser(client);
+
+            await expect(client.fkey).resolves.toEqual(mockFkey);
+        });
     });
 
     describe("Rooms", () => {
@@ -52,336 +84,302 @@ describe("Client", () => {
             expect(rooms.get(room2Id)?.id).toEqual(room2Id);
         });
 
-        test(Client.prototype.listUsers.name, async () => {
-            expect.assertions(2);
+        describe(Client.prototype.listUsers.name, () => {
+            test("Should correctly list users", async () => {
+                expect.assertions(2);
 
-            jest.doMock("../../src/Browser", () => {
-                const real = jest.requireActual<typeof import("../../src/Browser")>("../../src/Browser");
-                real.default.prototype.listUsers = async (_room) => {
-                    return [new User(new Client("stackexchange.com"), 42)];
-                };
-                return real;
+                const client = new Client("stackexchange.com");
+
+                mockBrowser({
+                    listUsers: () => Promise.resolve([new User(client, 42)]),
+                });
+                const { default: Browser } = await import("../../src/Browser");
+
+                client.browser = new Browser(client);
+
+                const users = await client.listUsers(42);
+
+                expect(users.length).toEqual(1);
+                expect(users[0].id).toEqual(42);
+            });
+        });
+
+        describe(Client.prototype.joinRoom.name, () => {
+            test("Should correctly join rooms", async () => {
+                expect.assertions(1);
+
+                mockBrowser({ joinRoom: () => Promise.resolve(true) });
+                const { default: Browser } = await import("../../src/Browser");
+
+                const client = new Client("stackoverflow.com");
+                client.browser = new Browser(client);
+                const room = client.getRoom(5);
+
+                await expect(room.join()).resolves.toBe(true);
+            });
+        });
+
+        describe(Client.prototype.leaveRoom.name, () => {
+            test("Should correctly leave rooms", async () => {
+                expect.assertions(1);
+
+                mockBrowser({ leaveRoom: () => Promise.resolve(true) });
+                const { default: Browser } = await import("../../src/Browser");
+
+                const client = new Client("meta.stackexchange.com");
+                client.browser = new Browser(client);
+                await client.joinRoom(42);
+
+                const status = await client.leaveRoom(42);
+                expect(status).toBe(true);
             });
 
-            const { default: Client } = await import("../../src/Client");
+            test("Should return false on failure", async () => {
+                expect.assertions(1);
 
-            const client = new Client("stackexchange.com");
+                mockBrowser({ leaveRoom: () => Promise.resolve(false) });
+                const { default: Browser } = await import("../../src/Browser");
 
-            const users = await client.listUsers(42);
+                const client = new Client("meta.stackexchange.com");
+                client.browser = new Browser(client);
+                await client.joinRoom(42);
 
-            expect(users.length).toEqual(1);
-            expect(users[0].id).toEqual(42);
+                const status = await client.leaveRoom(42);
+                expect(status).toBe(false);
+            });
+        });
+
+        describe(Client.prototype.leaveAll.name, () => {
+            test("Should correctly leave all rooms", async () => {
+                expect.assertions(1);
+
+                mockBrowser({
+                    joinRoom: () => Promise.resolve(true),
+                    leaveRoom: () => Promise.resolve(true),
+                });
+                const { default: Browser } = await import("../../src/Browser");
+
+                const client = new Client("meta.stackexchange.com");
+                client.browser = new Browser(client);
+                await client.joinRoom(42);
+
+                const status = await client.leaveAll();
+                expect(status).toBe(true);
+            });
+        });
+
+        describe(Client.prototype.createRoom.name, () => {
+            test("Should correctly create rooms", async () => {
+                expect.assertions(1);
+
+                mockBrowser({ createRoom: () => Promise.resolve(42) });
+                const { default: Browser } = await import("../../src/Browser");
+
+                const client = new Client("meta.stackexchange.com");
+                client.browser = new Browser(client);
+
+                const room = await client.createRoom(
+                    createRoomBody as IRoomSave
+                );
+
+                expect(room.id).toBe(42);
+            });
+        });
+
+        describe(Client.prototype.updateRoom.name, () => {
+            test("should correctly update rooms", async () => {
+                expect.assertions(1);
+
+                mockBrowser({ updateRoom: () => Promise.resolve(42) });
+                const { default: Browser } = await import("../../src/Browser");
+
+                const client = new Client("meta.stackexchange.com");
+                client.browser = new Browser(client);
+
+                const room = await client.updateRoom(
+                    42,
+                    updateRoomBody as IRoomSave
+                );
+
+                expect(room.id).toBe(42);
+            });
+        });
+
+        describe(Client.prototype.broadcast.name, () => {
+            test("should return a status map of roomId -> status", async () => {
+                expect.assertions(2);
+
+                const mockSend = jest.fn();
+
+                mockRoom({ sendMessage: mockSend });
+
+                const { default: Client } = await import("../../src/Client");
+                const client = new Client("meta.stackexchange.com");
+
+                const fineId = 42;
+                const brokenId = 24;
+
+                client.getRoom(fineId);
+                client.getRoom(brokenId);
+
+                mockSend
+                    .mockResolvedValueOnce(void 0)
+                    .mockRejectedValueOnce(void 0);
+
+                const statusMap = await client.broadcast(
+                    "BBC wants to apologize for the following"
+                );
+
+                expect(statusMap.get(fineId)).toBe(true);
+                expect(statusMap.get(brokenId)).toBe(false);
+            });
         });
     });
 
     describe("Login", () => {
-        test("Should return logged in user", async () => {
-            expect.assertions(2);
+        describe(Client.prototype.login.name, () => {
+            test("Should throw if missing email", async () => {
+                expect.assertions(1);
+    
+                await expect(
+                    new Client("stackoverflow.com").login("", "abc123")
+                ).rejects.toThrowError(InvalidArgumentError);
+            });
 
-            const host: Host = "stackoverflow.com";
+            test("Should throw if missing password", async () => {
+                expect.assertions(1);
+    
+                await expect(
+                    new Client("stackoverflow.com").login("text@example.com", "")
+                ).rejects.toThrowError(InvalidArgumentError);
+            });
 
-            const client = new Client(host);
-
-            class BrowserMock extends Browser {
-                loggedIn = true;
-                get userId() {
-                    return Promise.resolve(5);
-                }
-            }
-
-            client.browser = new BrowserMock(client);
-
-            const user = await client.getMe();
-
-            expect(user).toBeInstanceOf(User);
-            expect(user.id).toEqual(5);
+            test("Should throw if email is invalid", async () => {
+                expect.assertions(1);
+    
+                await expect(
+                    new Client("stackexchange.com").login("invalid", "a12B$")
+                ).rejects.toThrowError(InvalidArgumentError);
+            });
         });
 
-        test("Should throw if missing email", async () => {
-            expect.assertions(1);
-
-            await expect(
-                new Client("stackoverflow.com").login("", "abc123")
-            ).rejects.toThrowError(InvalidArgumentError);
-        });
-
-        test("Should throw if missing password", async () => {
-            expect.assertions(1);
-
-            await expect(
-                new Client("stackoverflow.com").login("text@example.com", "")
-            ).rejects.toThrowError(InvalidArgumentError);
-        });
-
-        test("Should throw if email is invalid", async () => {
-            expect.assertions(1);
-
-            await expect(
-                new Client("stackexchange.com").login("invalid", "a12B$")
-            ).rejects.toThrowError(InvalidArgumentError);
+        describe(Client.prototype.loginCookie.name, () => {
+            test("Should throw error if invalid cookieString", async () => {
+                expect.assertions(1);
+    
+                await expect(
+                    new Client("stackoverflow.com").loginCookie("")
+                ).rejects.toThrowError(InvalidArgumentError);
+            });
+    
+            test("Should attempt to login with a cookieString", async () => {
+                expect.assertions(2);
+    
+                const loginCookieMock = jest.fn();
+    
+                mockBrowser({ loginCookie: loginCookieMock });
+                const { default: Browser } = await import("../../src/Browser");
+    
+                const client = new Client("stackoverflow.com");
+                client.browser = new Browser(client);
+    
+                const cookieStr = "testing";
+    
+                await client.loginCookie(cookieStr);
+    
+                expect(loginCookieMock).toHaveBeenCalledTimes(1);
+                expect(loginCookieMock).toHaveBeenLastCalledWith(cookieStr);
+            });
         });
     });
 
     describe("Messages", () => {
-        test("Should correctly attempt to delete a message", async () => {
-            expect.assertions(1);
+        describe(Client.prototype.delete.name, () => {
+            test("Should correctly attempt to delete a message", async () => {
+                expect.assertions(1);
 
-            jest.doMock("../../src/Browser", () => {
-                const real = jest.requireActual("../../src/Browser");
-                real.default.prototype.deleteMessage = () => Promise.resolve(DeleteMessageStatus.SUCCESS);
-                return real;
+                mockBrowser({
+                    deleteMessage: () =>
+                        Promise.resolve(DeleteMessageStatus.SUCCESS),
+                });
+                const { default: Browser } = await import("../../src/Browser");
+
+                const client = new Client("meta.stackexchange.com");
+                client.browser = new Browser(client);
+                const status = await client.delete(42);
+
+                expect(status).toEqual(DeleteMessageStatus.SUCCESS);
             });
+        });
 
-            const { default: Client } = await import("../../src/Client");
+        describe(Client.prototype.getMessage.name, () => {
+            test("Should return a Message on 'getMessage'", () => {
+                expect.assertions(2);
 
-            const client = new Client("meta.stackexchange.com");
+                const client = new Client("meta.stackexchange.com");
 
-            const status = await client.delete(42);
+                const id = 29;
 
-            expect(status).toEqual(DeleteMessageStatus.SUCCESS);
+                const msg = client.getMessage(id);
+
+                expect(msg).toBeInstanceOf(Message);
+                expect(msg.id).toEqual(id);
+            });
         });
     });
 
-    test("Should throw error if invalid cookieString", async () => {
-        expect.assertions(1);
-
-        await expect(
-            new Client("stackoverflow.com").loginCookie("")
-        ).rejects.toThrowError(InvalidArgumentError);
-    });
-
-    test("Should attempt to login with a cookieString", async () => {
-        expect.assertions(2);
-
-        const loginCookieMock = jest.fn();
-
-        class BrowserMock extends Browser {
-            loginCookie = loginCookieMock;
-        }
-
-        const host: Host = "stackoverflow.com";
-
-        const client = new Client(host);
-
-        client.browser = new BrowserMock(client);
-
-        const cookieStr = "testing";
-
-        await client.loginCookie(cookieStr);
-
-        expect(loginCookieMock).toHaveBeenCalledTimes(1);
-        expect(loginCookieMock).toHaveBeenLastCalledWith(cookieStr);
-    });
-
-    test("Should return a Message on 'getMessage'", () => {
-        expect.assertions(2);
-
-        const host: Host = "meta.stackexchange.com";
-        const client = new Client(host);
-
-        const id = 29;
-
-        const msg = client.getMessage(id);
-
-        expect(msg).toBeInstanceOf(Message);
-        expect(msg.id).toEqual(id);
-    });
-
-    describe("Client user", () => {
-        test("Should return a User on 'getUser'", async () => {
-            expect.assertions(2);
-
-            const host: Host = "meta.stackexchange.com";
-            const client = new Client(host);
-
-            const id = 5;
-
-            const user = client.getUser(id);
-
-            expect(user).toBeInstanceOf(User);
-            expect(user.id).toEqual(id);
+    describe("Users", () => {
+        describe(Client.prototype.getMe.name, () => {
+            test("Should return the logged in user", async () => {
+                expect.assertions(1);
+    
+                const userId = 5;
+    
+                mockBrowser({ userId: Promise.resolve(userId) });
+                const { default: Browser } = await import("../../src/Browser");
+    
+                mockClient({ loggedIn: true });
+                const { default: Client } = await import("../../src/Client");
+    
+                const client = new Client("stackoverflow.com");
+                client.browser = new Browser(client);
+                const user = await client.getMe();
+    
+                expect(user.id).toEqual(userId);
+            });
         });
 
-        beforeEach(() => jest.resetModules());
+        describe(Client.prototype.getUser.name, () => {
+            test("Should return a User on 'getUser'", async () => {
+                expect.assertions(2);
 
-        test('Should skip initialization on subsequent calls to "getUser"', async () => {
-            expect.assertions(1);
+                const client = new Client("meta.stackexchange.com");
 
-            const mockUserConstructor = jest.fn();
+                const id = 5;
 
-            jest.doMock("../../src/User", () =>
-                jest.fn().mockImplementation(mockUserConstructor)
-            );
+                const user = client.getUser(id);
 
-            const { default: Client } = await import("../../src/Client");
-            const client = new Client("stackexchange.com");
-
-            const userId = 42;
-            client.getUser(userId, { about: "I am the answer" });
-            client.getUser(userId);
-
-            expect(mockUserConstructor).toBeCalledTimes(1);
-
-            jest.unmock("../../src/User");
+                expect(user).toBeInstanceOf(User);
+                expect(user.id).toEqual(id);
+            });
         });
     });
+});
 
-    test("Should attempt to join a room", async () => {
-        expect.assertions(2);
-
-        const roomId = 5;
-        const host: Host = "stackoverflow.com";
-
-        class BrowserMock extends Browser {
-            joinRoom = jest.fn(() => Promise.resolve(true));
-        }
-
-        const client = new Client(host);
-        const browser = new BrowserMock(client);
-        const room = client.getRoom(roomId);
-
-        const status = await room.join();
-
-        expect(browser.joinRoom).toHaveBeenCalledWith(room);
-        expect(status).toBe(true);
-    });
-
-    test("Should correctly get root", () => {
-        expect.assertions(1);
-
-        const hosts: Host[] = [
-            "meta.stackexchange.com",
-            "stackexchange.com",
-            "stackoverflow.com",
-        ];
-
-        const clients = hosts.map((host) => new Client(host));
-        const roots = clients.map(({ root }) => root);
-
-        expect(roots).toEqual([
-            "https://chat.meta.stackexchange.com/",
-            "https://chat.stackexchange.com/",
-            "https://chat.stackoverflow.com/",
-        ]);
-    });
-
+describe("Hosts", () => {
     beforeEach(() => jest.resetModules());
 
-    test("Should correctly get fkey", async () => {
-        expect.assertions(1);
+    describe(isAllowedHost.name, () => {
+        test("Should correctly determine if a host is allowed", () => {
+            expect.assertions(1 + AllowedHosts.length);
 
-        const mockFkey = "42";
+            const notAllowed = isAllowedHost("example.com");
+            expect(notAllowed).toEqual(false);
 
-        jest.doMock("../../src/Browser", () => {
-            const real = jest.requireActual("../../src/Browser");
-            Object.defineProperty(real.default.prototype, "chatFKey", {
-                get: () => Promise.resolve(mockFkey),
+            AllowedHosts.forEach((host) => {
+                const allowed = isAllowedHost(host);
+                expect(allowed).toEqual(true);
             });
-            return real;
-        });
-
-        const { default: Client } = await import("../../src/Client");
-
-        const client = new Client("stackexchange.com");
-
-        await expect(client.fkey).resolves.toEqual(mockFkey);
-    });
-
-    describe("leaving rooms", () => {
-        test("Should correctly leave all rooms", async () => {
-            expect.assertions(2);
-
-            const mockGot = jest.fn();
-
-            jest.doMock("got", () =>
-                Object.assign(mockGot, { extend: mockGot })
-            );
-
-            jest.doMock("../../src/Browser", () => {
-                const real = jest.requireActual("../../src/Browser");
-                real.default.joinRoom = () => Promise.resolve(true);
-                return real;
-            });
-
-            mockGot.mockReturnValue({
-                statusCode: 200,
-                body: "<input name='fkey' value='test'/>",
-            });
-
-            const { default: Client } = await import("../../src/Client");
-
-            const client = new Client("meta.stackexchange.com");
-
-            await client.joinRoom(42);
-
-            const status = await client.leaveAll();
-            expect(status).toBe(true);
-
-            const [_j1, _j2, _events, leave] = mockGot.mock.calls;
-
-            const [url] = leave;
-            expect(url).toMatch(/chats\/leave\/all/);
-        });
-
-        test("should return correct status on failing to leave rooms", async () => {
-            expect.assertions(1);
-
-            const mockGot = jest.fn();
-
-            jest.doMock("got", () =>
-                Object.assign(mockGot, { extend: mockGot })
-            );
-
-            mockGot.mockReturnValue({
-                statusCode: 200,
-                body: "<input name='fkey' value='test'/>",
-            });
-
-            const { default: Client } = await import("../../src/Client");
-
-            const client = new Client("meta.stackexchange.com");
-
-            await client.joinRoom(42);
-
-            mockGot.mockReturnValue({
-                statusCode: 301,
-                body: "sorry, we changed ship",
-            });
-
-            const status = await client.leaveAll();
-            expect(status).toBe(false);
-        });
-    });
-
-    describe("broadcasting", () => {
-        test("should return a status map of roomId -> status", async () => {
-            expect.assertions(2);
-
-            const mockSend = jest.fn();
-
-            jest.doMock("../../src/Room", () => {
-                const real = jest.requireActual<typeof import("../../src/Room")>("../../src/Room");
-                real.default.prototype.sendMessage = mockSend;
-                return real;
-            });
-
-            const { default: Client } = await import("../../src/Client");
-            const client = new Client("meta.stackexchange.com");
-
-            const fineId = 42;
-            const brokenId = 24;
-
-            client.getRoom(fineId);
-            client.getRoom(brokenId);
-
-            mockSend
-                .mockResolvedValueOnce(void 0)
-                .mockRejectedValueOnce(void 0);
-
-            const statusMap = await client.broadcast("BBC wants to apologize for the following");
-
-            expect(statusMap.get(fineId)).toBe(true);
-            expect(statusMap.get(brokenId)).toBe(false);
         });
     });
 });

--- a/tests/unit/room.test.ts
+++ b/tests/unit/room.test.ts
@@ -145,7 +145,7 @@ describe("Room", () => {
                     InvalidArgumentError
                 );
 
-                //@ts-expect-error
+                //@ts-ignore
                 expect(room.sendMessage()).rejects.toThrowError(
                     InvalidArgumentError
                 );
@@ -161,7 +161,7 @@ describe("Room", () => {
 
             const { WebSocket } = await import("ws");
 
-            //@ts-expect-error
+            //@ts-ignore
             const socket = new WebSocket(null);
 
             const mockWebsocketWatch = jest.fn(() => Promise.resolve(socket));
@@ -181,7 +181,7 @@ describe("Room", () => {
         it("Should correctly process message events", async () => {
             expect.assertions(2);
 
-            //@ts-expect-error
+            //@ts-ignore
             const socket = new WebSocket(null);
 
             mockBrowser({ watchRoom: () => Promise.resolve(socket) });
@@ -296,7 +296,7 @@ describe("Room", () => {
         it("should stop passing messages from blocked users", async () => {
             const events = { r42: { e: [{ user_id: 24 }, { user_id: 42 }] } };
 
-            // @ts-expect-error
+            // @ts-ignore
             const socket = new WebSocket(null);
 
             mockBrowser({ watchRoom: () => Promise.resolve(socket) });
@@ -369,7 +369,7 @@ describe("Room", () => {
                 },
             };
 
-            // @ts-expect-error
+            // @ts-ignore
             const socket = new WebSocket(null);
 
             mockBrowser({ watchRoom: () => Promise.resolve(socket) })

--- a/tests/unit/room.test.ts
+++ b/tests/unit/room.test.ts
@@ -1,28 +1,236 @@
-import { readFile } from "fs/promises";
 import WebSocket from "ws";
-import Browser from "../../src/Browser";
-import Client, { Host } from "../../src/Client";
+import Browser, { type IRoomSave } from "../../src/Browser";
+import Client, { type Host } from "../../src/Client";
 import InvalidArgumentError from "../../src/Exceptions/InvalidArgumentError";
 import Message from "../../src/Message";
 import Room from "../../src/Room";
 import User from "../../src/User";
-import type { ChatEvent } from "../../src/WebsocketEvent";
 import WebsocketEvent, { ChatEventType } from "../../src/WebsocketEvent";
+import chatEvent6 from "../events/6.json";
+import updateRoomBody from "../fixtures/update_room_body.json";
+import { makeMockClassExport } from "./utils";
+
+const mockBrowser = makeMockClassExport<Browser>("../../src/Browser");
+const mockClient = makeMockClassExport<Client>("../../src/Client");
+const mockWS = makeMockClassExport<WebSocket>("ws");
 
 describe("Room", () => {
+    beforeEach(() => jest.resetModules());
+    beforeEach(() => jest.useRealTimers());
+
+    describe("instantiation", () => {
+        it("Should instantiate with id", () => {
+            expect.assertions(1);
+
+            const roomId = 5;
+            const client = new Client("stackoverflow.com");
+            const room = new Room(client, roomId);
+            expect(room.id).toEqual(roomId);
+        });
+    });
 
     describe("getters", () => {
-        test("should correctly get transcript URL", () => {
+        it("should correctly get transcript URL", () => {
             const client = new Client("stackexchange.com");
             const { transcriptURL } = client.getRoom(42);
-            expect(transcriptURL).toEqual("https://chat.stackexchange.com/transcript/42");
+            expect(transcriptURL).toEqual(
+                "https://chat.stackexchange.com/transcript/42"
+            );
+        });
+    });
+
+    describe("room interaction", () => {
+        describe(Room.prototype.update.name, () => {
+            it(Room.prototype.update.name, async () => {
+                expect.assertions(1);
+
+                mockClient({
+                    updateRoom: (room) => Promise.resolve(room as Room),
+                });
+                const { default: MockedClient } = await import(
+                    "../../src/Client"
+                );
+
+                const room = new Room(
+                    new MockedClient("stackexchange.com"),
+                    42
+                );
+
+                await expect(
+                    room.update(updateRoomBody as IRoomSave)
+                ).resolves.toBe(true);
+            });
+        });
+
+        describe(Room.prototype.join.name, () => {
+            it("Should correctly join rooms", async () => {
+                expect.assertions(1);
+
+                mockClient({ joinRoom: () => Promise.resolve(true) });
+                const { default: Client } = await import("../../src/Client");
+
+                const client = new Client("stackoverflow.com");
+                const room = new Room(client, 5);
+
+                await expect(room.join()).resolves.toBe(true);
+            });
+        });
+
+        describe(Room.prototype.leave.name, () => {
+            it("Should correctly leave rooms", async () => {
+                expect.assertions(1);
+
+                mockClient({ leaveRoom: () => Promise.resolve(true) });
+                const { default: Client } = await import("../../src/Client");
+
+                const client = new Client("stackoverflow.com");
+                const room = new Room(client, 5);
+
+                await expect(room.leave()).resolves.toBe(true);
+            });
+        });
+
+        describe(Room.prototype.sendMessage.name, () => {
+            const client = new Client("stackoverflow.com");
+
+            it("Should attempt to send a message", async () => {
+                expect.assertions(2);
+
+                const host: Host = "stackoverflow.com";
+
+                mockClient({
+                    send: (content) =>
+                        Promise.resolve([
+                            true,
+                            new Message(client, 42, { content }),
+                        ]),
+                });
+
+                const { default: MockedClient } = await import(
+                    "../../src/Client"
+                );
+
+                const room = new Room(new MockedClient(host), 5);
+
+                const message = await room.sendMessage(
+                    "This is a test message"
+                );
+
+                expect(message.id).toEqual(42);
+                expect(message.content).resolves.toEqual(
+                    "This is a test message"
+                );
+            });
+
+            it("Should throw an error for text > 500 chars", async () => {
+                expect.assertions(1);
+
+                const room = new Room(client, 5);
+
+                expect(
+                    room.sendMessage(`
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean aliquet auctor sem, luctus sodales orci egestas id.
+                    Nullam sit amet mi turpis. Etiam nec nibh id dolor semper imperdiet ut vitae odio. Vestibulum sagittis est sed augue euismod finibus.
+                    Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Integer in dui non lectus pellentesque porta
+                    sit amet vitae est. In blandit felis non sapien consectetur egestas. Proin ac dignissim lectus. In hac massa nunc.`)
+                ).rejects.toThrowError(InvalidArgumentError);
+            });
+
+            it("Should throw an error for text is empty", async () => {
+                expect.assertions(2);
+
+                const room = new Room(client, 5);
+
+                expect(room.sendMessage("")).rejects.toThrowError(
+                    InvalidArgumentError
+                );
+
+                //@ts-expect-error
+                expect(room.sendMessage()).rejects.toThrowError(
+                    InvalidArgumentError
+                );
+            });
+        });
+    });
+
+    describe("room watching", () => {
+        it("Should attempt to watch the room, and attach websockets", async () => {
+            expect.assertions(1);
+
+            mockWS({ on: jest.fn() }, "WebSocket");
+
+            const { WebSocket } = await import("ws");
+
+            //@ts-expect-error
+            const socket = new WebSocket(null);
+
+            const mockWebsocketWatch = jest.fn(() => Promise.resolve(socket));
+
+            mockClient({ watch: mockWebsocketWatch });
+
+            const { default: Client } = await import("../../src/Client");
+
+            const client = new Client("stackoverflow.com");
+            const room = new Room(client, 5);
+
+            await room.watch();
+
+            expect(mockWebsocketWatch).toHaveBeenCalledWith(room);
+        });
+
+        it("Should correctly process message events", async () => {
+            expect.assertions(2);
+
+            //@ts-expect-error
+            const socket = new WebSocket(null);
+
+            mockBrowser({ watchRoom: () => Promise.resolve(socket) });
+            const { default: Browser } = await import("../../src/Browser");
+
+            const client = new Client("stackoverflow.com");
+            client.browser = new Browser(client);
+            const room = new Room(client, 5);
+
+            const wrappedEvent = { r5: { e: [chatEvent6] } };
+
+            await room.watch();
+
+            const promise = new Promise((r) => room.once("message", r));
+
+            socket.emit("message", JSON.stringify(wrappedEvent));
+
+            await expect(promise).resolves.toBeInstanceOf(Message);
+            await expect(promise).resolves.toHaveProperty("id", 44396284);
+        });
+    });
+
+    describe("room information", () => {
+        describe(Room.prototype.listUsers.name, () => {
+            it("should correctly list users", async () => {
+                expect.assertions(2);
+
+                const host: Host = "stackexchange.com";
+
+                mockClient({
+                    listUsers: () =>
+                        Promise.resolve([new User(new Client(host), 42)]),
+                });
+
+                const { default: MockedClient } = await import(
+                    "../../src/Client"
+                );
+
+                const room = new Room(new MockedClient(host), 42);
+
+                const users = await room.listUsers();
+                expect(users.length).toEqual(1);
+                expect(users[0].id).toEqual(42);
+            });
         });
     });
 
     describe("blocking users", () => {
-        beforeEach(() => jest.resetModules());
-
-        test("should correctly block users", () => {
+        it("should correctly block users", () => {
             expect.assertions(2);
             const client = new Client("stackoverflow.com");
             const roomId = 42;
@@ -38,7 +246,7 @@ describe("Room", () => {
             expect(room.isBlocked(user2)).toBe(true);
         });
 
-        test("should unblock users after a timeout if one passed", async () => {
+        it("should unblock users after a timeout if one passed", async () => {
             expect.assertions(2);
 
             const client = new Client("stackoverflow.com");
@@ -59,11 +267,9 @@ describe("Room", () => {
             await Promise.resolve();
 
             expect(room.isBlocked(user)).toBe(false);
-
-            jest.useRealTimers();
         });
 
-        test("should correctly unblock users", () => {
+        it("should correctly unblock users", () => {
             expect.assertions(4);
 
             const client = new Client("stackoverflow.com");
@@ -87,69 +293,38 @@ describe("Room", () => {
             expect(room.isBlocked(user2)).toBe(false);
         });
 
-        test("should stop passing messages from blocked users", async () => {
-            const mockGot = jest.fn();
-
-            mockGot
-                .mockResolvedValueOnce({
-                    statusCode: 200,
-                    body: { time: Date.now() },
-                })
-                .mockResolvedValueOnce({
-                    statusCode: 200,
-                    body: {
-                        url: "wss://chat.sockets.stackexchange.com/events/1/42",
-                    },
-                });
-
-            jest.doMock("got", () =>
-                Object.assign(mockGot, { extend: jest.fn() })
-            );
-
+        it("should stop passing messages from blocked users", async () => {
             const events = { r42: { e: [{ user_id: 24 }, { user_id: 42 }] } };
 
-            const mockWatchRoom = jest.fn(() => ({
-                on: (m: string, cbk: Function) =>
-                    m === "close" || cbk(JSON.stringify(events)),
-            }));
+            // @ts-expect-error
+            const socket = new WebSocket(null);
 
-            jest.doMock("../../src/Browser", () => {
-                const { default: Browser } =
-                    jest.requireActual("../../src/Browser");
-                return class MockBrowser extends Browser {
-                    get chatFKey() {
-                        return "abs";
-                    }
-                    watchRoom() {
-                        return mockWatchRoom();
-                    }
-                };
-            });
-
-            const { default: Room } = await import("../../src/Room");
-            const { default: Client } = await import("../../src/Client");
+            mockBrowser({ watchRoom: () => Promise.resolve(socket) });
+            const { default: Browser } = await import("../../src/Browser");
 
             const client = new Client("stackexchange.com");
-            const roomId = 42;
-            const userId = 24;
+            client.browser = new Browser(client);
+            const blockedUserId = 24;
 
-            const room = new Room(client, roomId);
-            room.block(userId);
-
-            const promise = new Promise((r) => room.on("message", r));
-
-            await room.join();
+            const room = new Room(client, 42);
+            room.block(blockedUserId);
             await room.watch();
 
-            const msg = (await promise) as WebsocketEvent;
-            expect(msg.userId).not.toBe(userId);
+            const promise = new Promise<WebsocketEvent>((r) =>
+                room.once("message", r)
+            );
+
+            socket.emit("message", JSON.stringify(events));
+
+            await expect(promise).resolves.not.toHaveProperty(
+                "userId",
+                blockedUserId
+            );
         });
     });
 
     describe("ignoring events", () => {
-        beforeEach(() => jest.resetModules());
-
-        test("should correctly ignore event types", () => {
+        it("should correctly ignore event types", () => {
             expect.assertions(1);
 
             const client = new Client("stackoverflow.com");
@@ -163,7 +338,7 @@ describe("Room", () => {
             expect(room.isIgnored(ignored)).toBe(true);
         });
 
-        test("should correctly unignore event types", () => {
+        it("should correctly unignore event types", () => {
             expect.assertions(2);
 
             const client = new Client("stackoverflow.com");
@@ -181,27 +356,7 @@ describe("Room", () => {
             expect(room.isIgnored(ignored)).toBe(false);
         });
 
-        jest.setTimeout(10000);
-
-        test("should not emit message events for ignored types", async () => {
-            const mockGot = jest.fn();
-
-            mockGot
-                .mockResolvedValueOnce({
-                    statusCode: 200,
-                    body: { time: Date.now() },
-                })
-                .mockResolvedValueOnce({
-                    statusCode: 200,
-                    body: {
-                        url: "wss://chat.sockets.stackexchange.com/events/1/42",
-                    },
-                });
-
-            jest.doMock("got", () =>
-                Object.assign(mockGot, { extend: jest.fn() })
-            );
-
+        it("should not emit message events for ignored types", async () => {
             const ignored = ChatEventType.USER_LEFT;
             const notIgnored = ChatEventType.MESSAGE_POSTED;
 
@@ -214,43 +369,33 @@ describe("Room", () => {
                 },
             };
 
-            const mockWatchRoom = jest.fn(() => ({
-                on: (m: string, cbk: Function) =>
-                    m === "close" || cbk(JSON.stringify(events)),
-            }));
+            // @ts-expect-error
+            const socket = new WebSocket(null);
 
-            jest.doMock("../../src/Browser", () => {
-                const { default: Browser } =
-                    jest.requireActual("../../src/Browser");
-                return class MockBrowser extends Browser {
-                    get chatFKey() {
-                        return "abs";
-                    }
-                    watchRoom() {
-                        return mockWatchRoom();
-                    }
-                };
-            });
-
-            const { default: Room } = await import("../../src/Room");
-            const { default: Client } = await import("../../src/Client");
+            mockBrowser({ watchRoom: () => Promise.resolve(socket) })
+            const { default: Browser } = await import("../../src/Browser");
 
             const client = new Client("stackexchange.com");
-            const roomId = 42;
+            client.browser = new Browser(client);
 
-            const room = new Room(client, roomId);
+            const room = new Room(client, 42);
             room.ignore(ignored);
 
-            const promise = new Promise((r) => room.on("message", r));
-
-            await room.join();
             await room.watch();
 
-            const msg = (await promise) as WebsocketEvent;
-            expect(msg.eventType).toBe(notIgnored);
+            const promise = new Promise<WebsocketEvent>((r) =>
+                room.on("message", r)
+            );
+
+            socket.emit("message", JSON.stringify(events));
+
+            await expect(promise).resolves.toHaveProperty(
+                "eventType",
+                notIgnored
+            );
         });
 
-        test("should ignore all other events if added via Room#only()", () => {
+        it("should ignore all other events if added via Room#only()", () => {
             const roomId = 5;
             const client = new Client("stackoverflow.com");
             const room = new Room(client, roomId);
@@ -262,218 +407,5 @@ describe("Room", () => {
                 expect(v === ChatEventType.FILE_ADDED || ignored).toBe(true);
             });
         });
-    });
-
-    it("Should create a room with id", () => {
-        expect.assertions(1);
-
-        const roomId = 5;
-        const client = new Client("stackoverflow.com");
-        const room = new Room(client, roomId);
-        expect(room.id).toEqual(roomId);
-    });
-
-    it("Should attempt to join/leave a room", async () => {
-        expect.assertions(2);
-
-        const roomId = 5;
-        const host: Host = "stackoverflow.com";
-
-        class MockBrowser extends Browser {
-            joinRoom = jest.fn();
-            leaveRoom = jest.fn();
-        }
-
-        const client = new Client(host);
-        const browser = new MockBrowser(client);
-        const room = new Room(client, roomId);
-
-        await room.join();
-        await room.leave();
-
-        expect(browser.joinRoom).toHaveBeenCalledWith(room);
-        expect(browser.leaveRoom).toHaveBeenCalledWith(room);
-    });
-
-    describe("sendMessage", () => {
-        it("Should attempt to send a message", async () => {
-            expect.assertions(1);
-
-            const roomId = 5;
-            const host: Host = "stackoverflow.com";
-
-            class MockBrowser extends Browser {
-                sendMessage = jest.fn();
-            }
-
-            const client = new Client(host);
-            const browser = new MockBrowser(client);
-            const room = new Room(client, roomId);
-
-            await room.sendMessage("This is a test message");
-
-            expect(browser.sendMessage).lastCalledWith(
-                roomId,
-                "This is a test message"
-            );
-        });
-
-        it("Should throw an error for text > 500 chars", async () => {
-            expect.assertions(1);
-
-            const roomId = 5;
-            const client = new Client("stackoverflow.com");
-            const room = new Room(client, roomId);
-
-            expect(
-                room.sendMessage(`
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean aliquet auctor sem, luctus sodales orci egestas id.
-                Nullam sit amet mi turpis. Etiam nec nibh id dolor semper imperdiet ut vitae odio. Vestibulum sagittis est sed augue euismod finibus.
-                Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Integer in dui non lectus pellentesque porta
-                sit amet vitae est. In blandit felis non sapien consectetur egestas. Proin ac dignissim lectus. In hac massa nunc.`)
-            ).rejects.toThrowError(InvalidArgumentError);
-        });
-
-        it("Should throw an error for text is empty", async () => {
-            expect.assertions(2);
-
-            const roomId = 5;
-
-            const client = new Client("stackoverflow.com");
-            const room = new Room(client, roomId);
-
-            expect(room.sendMessage("")).rejects.toThrowError(
-                InvalidArgumentError
-            );
-
-            //@ts-expect-error
-            expect(room.sendMessage()).rejects.toThrowError(
-                InvalidArgumentError
-            );
-        });
-    });
-
-    describe(Room.prototype.listUsers.name, () => {
-        test("should correctly list users", async () => {
-            expect.assertions(2);
-
-            class MockClient extends Client {
-                async listUsers(): Promise<User[]> {
-                    return [new User(this, 42)];
-                }
-            }
-
-            const room = new Room(new MockClient("stackexchange.com"), 42);
-
-            const users = await room.listUsers();
-            expect(users.length).toEqual(1);
-            expect(users[0].id).toEqual(42);
-        });
-    });
-
-    it("Should attempt to watch the room, and attach websockets", async () => {
-        expect.assertions(2);
-
-        const roomId = 5;
-        const host: Host = "stackoverflow.com";
-
-        const mockWebsocketOn = jest.fn();
-
-        class MockWebSocket extends WebSocket {
-            on = mockWebsocketOn;
-        }
-
-        //@ts-ignore
-        const socket = new MockWebSocket(null);
-
-        const mockWebsocketGetter = jest.fn(() => Promise.resolve(socket));
-
-        const mockWebsocketWatch = jest.fn(() => mockWebsocketGetter());
-
-        class MockBrowser extends Browser {
-            watchRoom = mockWebsocketWatch;
-        }
-
-        const client = new Client(host);
-        new MockBrowser(client);
-
-        const room = new Room(client, roomId);
-
-        await room.watch();
-
-        expect(mockWebsocketWatch).toHaveBeenCalledWith(room);
-        expect(mockWebsocketOn).toBeCalledTimes(2);
-    });
-
-    it("Should fire an event", async () => {
-        expect.assertions(11);
-
-        const roomId = 5;
-        const host: Host = "stackoverflow.com";
-
-        jest.doMock("ws", () => {
-            const ws = jest.requireActual("ws");
-            ws.prototype.close = () => void 0;
-            return ws;
-        });
-
-        const { default: WebSocket } = await import("ws");
-
-        //@ts-ignore
-        const websocketMock = new WebSocket(null);
-
-        class MockBrowser extends Browser {
-            sendMessage = jest.fn();
-            leaveRoom = jest.fn();
-            watchRoom = jest.fn(() => Promise.resolve(websocketMock));
-        }
-
-        const client = new Client(host);
-        const browser = new MockBrowser(client);
-
-        const room = new Room(client, roomId);
-
-        const event: ChatEvent = JSON.parse(
-            await readFile("./tests/events/6.json", { encoding: "utf-8" })
-        );
-
-        const wrappedEvent = { r5: { e: [event] } };
-
-        const messageSpy = jest.fn();
-        const closeSpy = jest.fn();
-
-        room.on("message", messageSpy);
-        room.on("close", closeSpy);
-
-        await room.watch();
-
-        websocketMock.emit("message", JSON.stringify(wrappedEvent));
-        websocketMock.emit("message", "{}");
-
-        expect(browser.watchRoom).toHaveBeenCalledTimes(1);
-        expect(browser.watchRoom).toHaveBeenCalledWith(room);
-
-        // Simulate server disconnect
-        websocketMock.emit("close");
-
-        expect(browser.watchRoom).toHaveBeenCalledTimes(2);
-        expect(browser.watchRoom).toHaveBeenCalledWith(room);
-
-        expect(messageSpy).toHaveBeenCalledTimes(1);
-        expect(closeSpy).toHaveBeenCalledTimes(0);
-        expect(browser.leaveRoom).toHaveBeenCalledTimes(0);
-
-        await room.leave();
-
-        expect(browser.leaveRoom).toHaveBeenCalledWith(room);
-
-        websocketMock.emit("close");
-
-        expect(closeSpy).toHaveBeenCalledTimes(1);
-
-        const [[msg]] = messageSpy.mock.calls;
-
-        expect(msg).toBeInstanceOf(Message);
-        expect(msg.id).toEqual(44396284);
     });
 });

--- a/tests/unit/utils.ts
+++ b/tests/unit/utils.ts
@@ -1,0 +1,45 @@
+/**
+ * @summary builds a helper for mocking class exports
+ * @param path path to the mocked module
+ */
+export const makeMockClassExport = <T>(path: string) => {
+    /**
+     * @param mockedProps a map property names to their mocks
+     * @param name export name (defaults to "default")
+     */
+    return <U extends Partial<T>>(mockedProps: U, name = "default") => {
+        // ensures the module state is reset between tests
+        jest.dontMock(path);
+
+        const actual = jest.requireActual(path);
+        const mocked = actual[name];
+
+        return jest.doMock(path, () => {
+            const props: PropertyDescriptorMap = {};
+
+            for (const [k, v] of Object.entries(mockedProps)) {
+                const prop = Object.getOwnPropertyDescriptor(
+                    mocked.prototype,
+                    k
+                );
+
+                const descriptor: PropertyDescriptor = {
+                    configurable: prop?.configurable,
+                    enumerable: prop?.enumerable,
+                    writable: prop?.writable,
+                    value: v,
+                };
+
+                props[k] = descriptor;
+            }
+
+            Object.defineProperties(mocked.prototype, props);
+
+            return {
+                __esModule: true,
+                ...actual,
+                [name]: mocked,
+            };
+        });
+    };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "moduleResolution": "node",
     "strict": true,
     "noEmitOnError": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "resolveJsonModule": true
   },
   "include": ["src"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
This PR adds room creation/updating functionality to the package (`Browser` class low-level methods and proxy methods for the `Client` and `Room` classes). 

The PR also reworks unit tests for the three main classes (`Browser`, `Client`, `Room`), including:

- ensuring consistency in test case/suite structure;
- switching to a dedicated mocking utility (DRY);
- switching to black box testing for high-level methods;
- importing JSON mocks/fixtures directly as JSON modules;